### PR TITLE
Support binary symbol names and unicode

### DIFF
--- a/Name.xs
+++ b/Name.xs
@@ -74,6 +74,7 @@ subname(name, sub)
 		namelen -= end - nameptr;
 	}
 
+	#ifdef PERL_VERSION < 10
 	/* under debugger, provide information about sub location */
 	if (PL_DBsub && CvGV(cv)) {
 		HV *hv = GvHV(PL_DBsub);
@@ -107,6 +108,7 @@ subname(name, sub)
 		}
 		Safefree(full_name);
 	}
+	#endif
 
 	gv = (GV *) newSV(0);
 	gv_init_pvn(gv, stash, nameptr, s - nameptr, GV_ADDMULTI | utf8flag);

--- a/Name.xs
+++ b/Name.xs
@@ -7,6 +7,8 @@
 #include "EXTERN.h"
 #include "perl.h"
 #include "XSUB.h"
+#define NEED_sv_2pv_flags
+#define NEED_gv_fetchpvn_flags
 #include "ppport.h"
 
 static MGVTBL subname_vtbl;
@@ -29,14 +31,17 @@ PROTOTYPES: DISABLE
 
 void
 subname(name, sub)
-	char *name
+	SV *name
 	SV *sub
     PREINIT:
 	CV *cv = NULL;
 	GV *gv;
 	HV *stash = CopSTASH(PL_curcop);
-	char *s, *end = NULL;
+	const char *s, *end = NULL;
 	MAGIC *mg;
+	STRLEN namelen;
+	int utf8flag = SvUTF8(name);
+	const char* nameptr = SvPV(name, namelen);
     PPCODE:
 	if (!SvROK(sub) && SvGMAGICAL(sub))
 		mg_get(sub);
@@ -49,25 +54,25 @@ subname(name, sub)
 	else if (PL_op->op_private & HINT_STRICT_REFS)
 		croak("Can't use string (\"%.32s\") as %s ref while \"strict refs\" in use",
 		      SvPV_nolen(sub), "a subroutine");
-	else if ((gv = gv_fetchpv(SvPV_nolen(sub), FALSE, SVt_PVCV)))
+	else if ((gv = gv_fetchsv(sub, FALSE, SVt_PVCV)))
 		cv = GvCVu(gv);
 	if (!cv)
 		croak("Undefined subroutine %s", SvPV_nolen(sub));
 	if (SvTYPE(cv) != SVt_PVCV && SvTYPE(cv) != SVt_PVFM)
 		croak("Not a subroutine reference");
-	for (s = name; *s++; ) {
+
+	for (s = nameptr; s <= nameptr + namelen; s++) {
 		if (*s == ':' && s[-1] == ':')
 			end = ++s;
 		else if (*s && s[-1] == '\'')
 			end = s;
 	}
 	s--;
-        if (end) {
-		char *namepv = savepvn(name, end - name);
-		stash = GvHV(gv_fetchpv(namepv, TRUE, SVt_PVHV));
-		Safefree(namepv);
-                name = end;
-        }
+	if (end) {
+		stash = GvHV(gv_fetchpvn_flags(nameptr, end - nameptr, GV_ADD | utf8flag, SVt_PVHV));
+		nameptr = end;
+		namelen -= end - nameptr;
+	}
 
 	/* under debugger, provide information about sub location */
 	if (PL_DBsub && CvGV(cv)) {
@@ -80,7 +85,7 @@ subname(name, sub)
 		char* old_pkg = HvNAME( GvSTASH(CvGV(cv)) );
 
 		int old_len = strlen(old_name) + strlen(old_pkg);
-		int new_len = strlen(name) + strlen(new_pkg);
+		int new_len = namelen + strlen(new_pkg);
 
 		char* full_name;
 		Newxz(full_name, (old_len > new_len ? old_len : new_len) + 3, char);
@@ -94,7 +99,7 @@ subname(name, sub)
 		if (old_data) {
 			strcpy(full_name, new_pkg);
 			strcat(full_name, "::");
-			strcat(full_name, name);
+			strcat(full_name, nameptr);
 
 			SvREFCNT_inc(*old_data);
 			if (!hv_store(hv, full_name, strlen(full_name), *old_data, 0))
@@ -104,7 +109,7 @@ subname(name, sub)
 	}
 
 	gv = (GV *) newSV(0);
-	gv_init(gv, stash, name, s - name, TRUE);
+	gv_init_pvn(gv, stash, nameptr, s - nameptr, GV_ADDMULTI | utf8flag);
 
 	mg = SvMAGIC(cv);
 	while (mg && mg->mg_virtual != &subname_vtbl)

--- a/Name.xs
+++ b/Name.xs
@@ -37,11 +37,12 @@ subname(name, sub)
 	CV *cv = NULL;
 	GV *gv;
 	HV *stash = CopSTASH(PL_curcop);
-	const char *s, *end = NULL;
+	const char *s, *end = NULL, *begin = NULL;
 	MAGIC *mg;
 	STRLEN namelen;
 	int utf8flag = SvUTF8(name);
 	const char* nameptr = SvPV(name, namelen);
+	int seen_quote = 0, need_subst = 0;
     PPCODE:
 	if (!SvROK(sub) && SvGMAGICAL(sub))
 		mg_get(sub);
@@ -62,16 +63,43 @@ subname(name, sub)
 		croak("Not a subroutine reference");
 
 	for (s = nameptr; s <= nameptr + namelen; s++) {
-		if (*s == ':' && s[-1] == ':')
-			end = ++s;
-		else if (*s && s[-1] == '\'')
-			end = s;
+		if (*s == ':' && s[-1] == ':') {
+			end = s - 1;
+			begin = ++s;
+			if (seen_quote)
+				seen_quote++;
+		}
+		else if (*s && s[-1] == '\'') {
+			end = s - 1;
+			begin = s;
+			seen_quote++;
+		}
 	}
 	s--;
 	if (end) {
-		stash = GvHV(gv_fetchpvn_flags(nameptr, end - nameptr, GV_ADD | utf8flag, SVt_PVHV));
-		nameptr = end;
-		namelen -= end - nameptr;
+		SV* tmp;
+		if (seen_quote > 1) {
+			STRLEN length = end - nameptr + seen_quote;
+			char* left;
+			int i, j;
+			tmp = newSV(length);
+			left = SvPVX(tmp);
+			for (i = 0, j = 0; j <= end - nameptr; ++i, ++j) {
+				if (nameptr[j] == '\'') {
+					left[i] = ':';
+					left[++i] = ':';
+				}
+				else {
+					left[i] = nameptr[j];
+				}
+			}
+			stash = gv_stashpvn(left, i - 2, GV_ADD | utf8flag);
+			SvREFCNT_dec(tmp);
+		}
+		else
+			stash = gv_stashpvn(nameptr, end - nameptr, GV_ADD | utf8flag);
+		nameptr = begin;
+		namelen -= begin - nameptr;
 	}
 
 	#ifdef PERL_VERSION < 10

--- a/t/exotic_names.t
+++ b/t/exotic_names.t
@@ -11,6 +11,13 @@ use B 'svref_2object';
 # a heuristic with ambiguous eval and looking for octets in the stash
 use if $] >= 5.016, feature => 'unicode_eval';
 
+if ($] >= 5.008) {
+	my $builder = Test::More->builder;
+	binmode $builder->output,         ":encoding(utf8)";
+	binmode $builder->failure_output, ":encoding(utf8)";
+	binmode $builder->todo_output,    ":encoding(utf8)";
+}
+
 sub compile_named_sub {
     my ( $fullname, $body ) = @_;
     my $sub = eval "sub $fullname { $body }" . '\\&{$fullname}';

--- a/t/exotic_names.t
+++ b/t/exotic_names.t
@@ -1,0 +1,91 @@
+use strict;
+use warnings;
+
+use Test::More;
+use B 'svref_2object';
+
+# This is a mess. The stash can supposedly handle Unicode but the behavior
+# is literally undefined before 5.16 (with crashes beyond the basic plane),
+# and remains unclear past 5.16 with evalbytes and feature unicode_eval
+# In any case - Sub::Name needs to *somehow* work with this, so we will do
+# a heuristic with ambiguous eval and looking for octets in the stash
+use if $] >= 5.016, feature => 'unicode_eval';
+
+sub compile_named_sub {
+    my ( $fullname, $body ) = @_;
+    my $sub = eval "sub $fullname { $body }" . '\\&{$fullname}';
+    return $sub if $sub;
+    my $e = $@;
+    require Carp;
+    Carp::croak $e;
+}
+
+sub caller3_ok {
+    my ( $sub, $expected, $type, $ord ) = @_;
+
+    local $Test::Builder::Level = $Test::Builder::Level + 1;
+
+    my $for_what = sprintf "when it contains \\x%s ( %s )", (
+        ( ($ord > 255)
+            ? sprintf "{%X}", $ord
+            : sprintf "%02X", $ord
+        ),
+        (
+            $ord > 255                    ? unpack('H*', pack 'C0U', $ord )
+            : ($ord > 0x1f and $ord < 0x7f) ? sprintf "%c", $ord
+            :                                 sprintf '\%o', $ord
+        ),
+    );
+
+    $expected =~ s/'/::/g;
+
+    # this is apparently how things worked before 5.16
+    utf8::encode($expected) if $] < 5.016 and $ord > 255;
+
+    my $stash_name = join '::', map { $_->STASH->NAME, $_->NAME } svref_2object($sub)->GV;
+
+    is $stash_name, $expected, "stash name for $type is correct $for_what";
+    is $sub->(), $expected, "caller() in $type returns correct name $for_what";
+}
+
+#######################################################################
+
+my @ordinal = ( 1 .. 255 );
+
+# 5.14 is the first perl to start properly handling \0 in identifiers
+unshift @ordinal, 0
+    unless $] < 5.014;
+
+# Unicode in 5.6 is not sane (crashes etc)
+push @ordinal,
+    0x100,    # LATIN CAPITAL LETTER A WITH MACRON
+    0x498,    # CYRILLIC CAPITAL LETTER ZE WITH DESCENDER
+    0x2122,   # TRADE MARK SIGN
+    0x1f4a9,  # PILE OF POO
+    unless $] < 5.008;
+
+plan tests => @ordinal * 2;
+
+my $legal_ident_char = "A-Z_a-z0-9'";
+$legal_ident_char .= join '', map chr, 0x100, 0x498
+    unless $] < 5.008;
+
+for my $ord (@ordinal) {
+    my $sub;
+    my $pkg      = sprintf 'test::SOME_%c_STASH', $ord;
+    my $subname  = sprintf 'SOME_%c_NAME', $ord;
+    my $fullname = join '::', $pkg, $subname;
+
+    # test that we can *always* compile at least within the correct package
+    my $expected;
+    if ( chr($ord) =~ m/^[$legal_ident_char]$/o ) { # compile directly
+        $expected = $fullname;
+        $sub = compile_named_sub $fullname => '(caller(0))[3]';
+    }
+    else { # not a legal identifier but at least test the package name by aliasing
+        $expected = "${pkg}::foo";
+        { no strict 'refs'; *palatable:: = *{"${pkg}::"} } # now palatable:: literally means ${pkg}::
+        $sub = compile_named_sub 'palatable::foo' => '(caller(0))[3]';
+    }
+    caller3_ok $sub, $expected, 'natively compiled sub', $ord;
+}

--- a/t/exotic_names.t
+++ b/t/exotic_names.t
@@ -50,6 +50,8 @@ sub caller3_ok {
 
 #######################################################################
 
+use Sub::Name 'subname';
+
 my @ordinal = ( 1 .. 255 );
 
 # 5.14 is the first perl to start properly handling \0 in identifiers
@@ -64,7 +66,7 @@ push @ordinal,
     0x1f4a9,  # PILE OF POO
     unless $] < 5.008;
 
-plan tests => @ordinal * 2;
+plan tests => @ordinal * 2 * 2;
 
 my $legal_ident_char = "A-Z_a-z0-9'";
 $legal_ident_char .= join '', map chr, 0x100, 0x498
@@ -75,6 +77,9 @@ for my $ord (@ordinal) {
     my $pkg      = sprintf 'test::SOME_%c_STASH', $ord;
     my $subname  = sprintf 'SOME_%c_NAME', $ord;
     my $fullname = join '::', $pkg, $subname;
+
+    $sub = subname $fullname => sub { (caller(0))[3] };
+    caller3_ok $sub, $fullname, 'renamed closure', $ord;
 
     # test that we can *always* compile at least within the correct package
     my $expected;


### PR DESCRIPTION
This combines the tests from #5 with fixes of my own to make Sub::Name both Unicode compatible and binary safe on perls that support that (within rules that perl has for names: `::` and `'` are treated as namespace separators, so they can't be otherwise used in the name).

This PR depends on mhx/Devel-PPPort#32 being released first, without that it will fail for lack of gv_init_pvn (5.10 and lower) and gv_fetchpvn_flags (5.8 and lower)