### PR TITLE
Failing test for exotic names in %DB::sub

### DIFF
--- a/Name.xs
+++ b/Name.xs
@@ -10,6 +10,7 @@
 #define NEED_sv_2pv_flags
 #define NEED_newSVpvn_flags
 #define NEED_gv_fetchpvn_flags
+#define NEED_sv_catpvn_flags
 #include "ppport.h"
 
 static MGVTBL subname_vtbl;
@@ -48,6 +49,10 @@ static MGVTBL subname_vtbl;
 
 #ifndef SV_CATBYTES
 #define SV_CATBYTES 0
+#endif
+
+#ifndef sv_catpvn_flags
+#define sv_catpvn_flags(b,n,l,f) sv_catpvn(b,n,l)
 #endif
 
 MODULE = Sub::Name  PACKAGE = Sub::Name

--- a/Name.xs
+++ b/Name.xs
@@ -8,6 +8,7 @@
 #include "perl.h"
 #include "XSUB.h"
 #define NEED_sv_2pv_flags
+#define NEED_newSVpvn_flags
 #define NEED_gv_fetchpvn_flags
 #include "ppport.h"
 
@@ -23,6 +24,30 @@ static MGVTBL subname_vtbl;
 
 #ifndef Newxz
 #define Newxz(ptr, num, type)	Newz(0, ptr, num, type)
+#endif
+
+#ifndef HvNAMELEN_get
+#define HvNAMELEN_get(stash) strlen(HvNAME(stash))
+#endif
+
+#ifndef HvNAMEUTF8
+#define HvNAMEUTF8(stash) 0
+#endif
+
+#ifndef GvNAMEUTF8
+#ifdef GvNAME_HEK
+#define GvNAMEUTF8(gv) HEK_UTF8(GvNAME_HEK(gv))
+#else
+#define GvNAMEUTF8(gv) 0
+#endif
+#endif
+
+#ifndef SV_CATUTF8
+#define SV_CATUTF8 0
+#endif
+
+#ifndef SV_CATBYTES
+#define SV_CATBYTES 0
 #endif
 
 MODULE = Sub::Name  PACKAGE = Sub::Name
@@ -103,41 +128,31 @@ subname(name, sub)
 		namelen -= begin - nameptr;
 	}
 
-	#ifdef PERL_VERSION < 10
 	/* under debugger, provide information about sub location */
 	if (PL_DBsub && CvGV(cv)) {
-		HV *hv = GvHV(PL_DBsub);
-		SV** old_data;
+		HV* DBsub = GvHV(PL_DBsub);
+		HE* old_data;
 
-		char* new_pkg = HvNAME(stash);
+		GV* oldgv = CvGV(cv);
+		HV* oldhv = GvSTASH(oldgv);
+		SV* old_full_name = newSVpvn_flags(HvNAME(oldhv), HvNAMELEN_get(oldhv), HvNAMEUTF8(oldhv) ? SVf_UTF8 : 0);
+		sv_catpvn(old_full_name, "::", 2);
+		sv_catpvn_flags(old_full_name, GvNAME(oldgv), GvNAMELEN(oldgv), GvNAMEUTF8(oldgv) ? SV_CATUTF8 : SV_CATBYTES);
 
-		char* old_name = GvNAME( CvGV(cv) );
-		char* old_pkg = HvNAME( GvSTASH(CvGV(cv)) );
+		old_data = hv_fetch_ent(DBsub, old_full_name, 0, 0);
 
-		int old_len = strlen(old_name) + strlen(old_pkg);
-		int new_len = namelen + strlen(new_pkg);
+		SvREFCNT_dec(old_full_name);
 
-		char* full_name;
-		Newxz(full_name, (old_len > new_len ? old_len : new_len) + 3, char);
-
-		strcat(full_name, old_pkg);
-		strcat(full_name, "::");
-		strcat(full_name, old_name);
-
-		old_data = hv_fetch(hv, full_name, strlen(full_name), 0);
-
-		if (old_data) {
-			strcpy(full_name, new_pkg);
-			strcat(full_name, "::");
-			strcat(full_name, nameptr);
-
-			SvREFCNT_inc(*old_data);
-			if (!hv_store(hv, full_name, strlen(full_name), *old_data, 0))
-				SvREFCNT_dec(*old_data);
+		if (old_data && HeVAL(old_data)) {
+			SV* new_full_name = newSVpvn_flags(HvNAME(stash), HvNAMELEN_get(stash), HvNAMEUTF8(stash) ? SVf_UTF8 : 0);
+			sv_catpvn(new_full_name, "::", 2);
+			sv_catpvn_flags(new_full_name, nameptr, s - nameptr, utf8flag ? SV_CATUTF8 : SV_CATBYTES);
+			SvREFCNT_inc(HeVAL(old_data));
+			if (hv_store_ent(DBsub, new_full_name, HeVAL(old_data), 0) != NULL)
+				SvREFCNT_inc(HeVAL(old_data));
+			SvREFCNT_dec(new_full_name);
 		}
-		Safefree(full_name);
 	}
-	#endif
 
 	gv = (GV *) newSV(0);
 	gv_init_pvn(gv, stash, nameptr, s - nameptr, GV_ADDMULTI | utf8flag);

--- a/lib/Sub/Name.pm
+++ b/lib/Sub/Name.pm
@@ -56,7 +56,8 @@ use warnings;
 
 our $VERSION = '0.21';
 
-use Exporter 5.57 'import';
+use Exporter ();
+*import = \&Exporter::import;
 
 our @EXPORT = qw(subname);
 our @EXPORT_OK = @EXPORT;

--- a/t/RT96893_perlcc.t
+++ b/t/RT96893_perlcc.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More 0.88;
+use Test::More;
 
 plan skip_all => 'B::C required for testing perlcc -O3'
     unless eval "require B::C;";

--- a/t/exotic_names.t
+++ b/t/exotic_names.t
@@ -104,8 +104,10 @@ for my $ord (@ordinal) {
           no strict 'refs';
           *palatable:: = *{"aliased::native::${pkg}::"};
           # now palatable:: literally means aliased::native::${pkg}::
-          ${"palatable::$subname"} = 1;
-          ${"palatable::"}{"sub"} = ${"palatable::"}{$subname};
+          my $encoded_sub = $subname;
+          utf8::encode($encoded_sub) if "$]" < 5.016 and $ord > 255;
+          ${"palatable::$encoded_sub"} = 1;
+          ${"palatable::"}{"sub"} = ${"palatable::"}{$encoded_sub};
           # and palatable::sub means aliased::native::${pkg}::${subname}
         }
         $sub = compile_named_sub 'palatable::sub' => '(caller(0))[3]';

--- a/t/exotic_names.t
+++ b/t/exotic_names.t
@@ -99,9 +99,16 @@ for my $ord (@ordinal) {
         $sub = compile_named_sub $expected => '(caller(0))[3]';
     }
     else { # not a legal identifier but at least test the package name by aliasing
-        $expected = "${pkg}::foo";
-        { no strict 'refs'; *palatable:: = *{"${pkg}::"} } # now palatable:: literally means ${pkg}::
-        $sub = compile_named_sub 'palatable::foo' => '(caller(0))[3]';
+        $expected = "aliased::native::$fullname";
+        {
+          no strict 'refs';
+          *palatable:: = *{"aliased::native::${pkg}::"};
+          # now palatable:: literally means aliased::native::${pkg}::
+          ${"palatable::$subname"} = 1;
+          ${"palatable::"}{"sub"} = ${"palatable::"}{$subname};
+          # and palatable::sub means aliased::native::${pkg}::${subname}
+        }
+        $sub = compile_named_sub 'palatable::sub' => '(caller(0))[3]';
     }
     caller3_ok $sub, $expected, 'natively compiled sub', $ord;
 }

--- a/t/exotic_names.t
+++ b/t/exotic_names.t
@@ -54,7 +54,13 @@ sub caller3_ok {
 
     is $stash_name, $expected, "stash name for $type is correct $for_what";
     is $sub->(), $expected, "caller() in $type returns correct name $for_what";
-    ok $DB::sub{$expected}, "%DB::sub entry for $type is correct $for_what";
+    SKIP: {
+      skip '%DB::sub not populated when enabled at runtime', 1
+        unless keys %DB::sub;
+      my ($prefix) = $expected =~ /^(.*?test::[^:]+::)/;
+      my ($db_found) = grep /^$prefix/, keys %DB::sub;
+      is $db_found, $expected, "%DB::sub entry for $type is correct $for_what";
+    }
 }
 
 #######################################################################

--- a/t/exotic_names.t
+++ b/t/exotic_names.t
@@ -3,6 +3,7 @@ use warnings;
 
 use Test::More;
 use B 'svref_2object';
+BEGIN { $^P |= 0x210 }
 
 # This is a mess. The stash can supposedly handle Unicode but the behavior
 # is literally undefined before 5.16 (with crashes beyond the basic plane),
@@ -53,6 +54,7 @@ sub caller3_ok {
 
     is $stash_name, $expected, "stash name for $type is correct $for_what";
     is $sub->(), $expected, "caller() in $type returns correct name $for_what";
+    ok $DB::sub{$expected}, "%DB::sub entry for $type is correct $for_what";
 }
 
 #######################################################################
@@ -73,16 +75,18 @@ push @ordinal,
     0x1f4a9,  # PILE OF POO
     unless "$]" < 5.008;
 
-plan tests => @ordinal * 2 * 2;
+plan tests => @ordinal * 2 * 3;
 
 my $legal_ident_char = "A-Z_a-z0-9'";
 $legal_ident_char .= join '', map chr, 0x100, 0x498
     unless "$]" < 5.008;
 
+my $uniq = 'A000';
 for my $ord (@ordinal) {
     my $sub;
-    my $pkg      = sprintf 'test::SOME_%c_STASH', $ord;
-    my $subname  = sprintf 'SOME_%c_NAME', $ord;
+    $uniq++;
+    my $pkg      = sprintf 'test::%s::SOME_%c_STASH', $uniq, $ord;
+    my $subname  = sprintf 'SOME_%s_%c_NAME', $uniq, $ord;
     my $fullname = join '::', $pkg, $subname;
 
     $sub = subname $fullname => sub { (caller(0))[3] };
@@ -91,8 +95,8 @@ for my $ord (@ordinal) {
     # test that we can *always* compile at least within the correct package
     my $expected;
     if ( chr($ord) =~ m/^[$legal_ident_char]$/o ) { # compile directly
-        $expected = $fullname;
-        $sub = compile_named_sub $fullname => '(caller(0))[3]';
+        $expected = "native::$fullname";
+        $sub = compile_named_sub $expected => '(caller(0))[3]';
     }
     else { # not a legal identifier but at least test the package name by aliasing
         $expected = "${pkg}::foo";

--- a/t/quotes-bug.t
+++ b/t/quotes-bug.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More 0.88;
+use Test::More tests => 1;
 use Sub::Name;
 
 my $sub = sub { (caller(0))[3] };
@@ -13,5 +13,3 @@ is(
     "foo::quz::bar::baz",
     'correctly parsed single quote from name where the last separator is ::',
 );
-
-done_testing;

--- a/t/smoke.t
+++ b/t/smoke.t
@@ -3,7 +3,7 @@ use warnings;
 
 BEGIN { $^P |= 0x210 }
 
-use Test::More 0.88;
+use Test::More tests => 10;
 use Sub::Name;
 
 my $x = subname foo => sub { (caller 0)[3] };
@@ -40,5 +40,4 @@ for ("Blork:: Bar!", "Foo::Bar::Baz") {
     ::is($DB::sub{$_}, $anon);
 }
 
-::done_testing;
 # vim: ft=perl


### PR DESCRIPTION
This has a test to demonstrate that %DB::sub isn't being populated correctly for sub names with wide characters or nulls.  When using aliased stash entries and globs, the %DB::sub entries are populated correctly.