### PR TITLE
test for renaming lexical subs

### DIFF
--- a/t/lexical.t
+++ b/t/lexical.t
@@ -1,0 +1,31 @@
+use strict;
+use warnings;
+
+use Test::More;
+BEGIN {
+  if ("$]" < 5.018) {
+    plan 'skip_all' => 'lexical subs not supported on this perl';
+  }
+}
+
+use feature 'lexical_subs';
+no warnings 'experimental::lexical_subs';
+
+use Sub::Name;
+
+local $TODO = "lexical subs unnameable until perl 5.22"
+  unless "$]" >= 5.022;
+
+my $foo = sub { (caller 0)[3] };
+
+my sub foo { (caller 0)[3] }
+
+subname 'main::foo2' => \&foo;
+is foo(), 'main::foo2', 'lexical subs can be named';
+
+my $x = 3;
+my sub bar { (caller 0)[$x] }
+subname 'main::bar2' => \&bar;
+is bar(), 'main::bar2', 'lexical closure subs can be named';
+
+done_testing;


### PR DESCRIPTION
Renaming lexical subs works on perl 5.22+.  I'm not sure if it can be made to work on 5.18 and 5.20, or if we even care about that.